### PR TITLE
Add hashtag groups page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import Admin from "./pages/Admin";
+import HashtagGroups from "./pages/HashtagGroups";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -19,6 +20,7 @@ const App = () => (
         <Routes>
           <Route path="/" element={<Index />} />
           <Route path="/admin" element={<Admin />} />
+          <Route path="/hashtags" element={<HashtagGroups />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -28,6 +28,12 @@ export const Header = () => {
               <Search className="h-4 w-4" />
               <span>Поиск и фильтрация материалов</span>
             </div>
+            <button
+              onClick={() => navigate('/hashtags')}
+              className="text-sm text-blue-600 hover:underline"
+            >
+              Хештеги
+            </button>
           </div>
         </div>
       </div>

--- a/src/pages/HashtagGroups.tsx
+++ b/src/pages/HashtagGroups.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { Header } from '@/components/Header';
+import { LoadingSpinner } from '@/components/LoadingSpinner';
+
+interface Post {
+  id: string;
+  title: string;
+  hashtags: string[];
+  telegram_url: string;
+}
+
+const HashtagGroups = () => {
+  const { data: posts = [], isLoading } = useQuery({
+    queryKey: ['hashtag-groups'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('posts')
+        .select('id, title, hashtags, telegram_url, published_at')
+        .order('published_at', { ascending: false });
+      if (error) throw error;
+      return data as Post[];
+    },
+  });
+
+  const hashtagMap = React.useMemo(() => {
+    const map: Record<string, Post[]> = {};
+    posts.forEach((post) => {
+      post.hashtags.forEach((tag) => {
+        const key = tag.trim();
+        if (!map[key]) map[key] = [];
+        map[key].push(post);
+      });
+    });
+    return map;
+  }, [posts]);
+
+  const sortedHashtags = React.useMemo(
+    () => Object.keys(hashtagMap).sort((a, b) => a.localeCompare(b)),
+    [hashtagMap]
+  );
+
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
+      <Header />
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="text-2xl font-bold mb-6">Хештеги</h1>
+        {sortedHashtags.length === 0 ? (
+          <p className="text-gray-500">Хештеги не найдены</p>
+        ) : (
+          <div className="space-y-8">
+            {sortedHashtags.map((tag) => (
+              <div key={tag} className="bg-white shadow rounded-lg p-4">
+                <h2 className="text-xl font-semibold mb-2">
+                  #{tag}{' '}
+                  <span className="text-sm text-gray-500">({hashtagMap[tag].length})</span>
+                </h2>
+                <ul className="list-disc pl-5 space-y-1">
+                  {hashtagMap[tag].map((post) => (
+                    <li key={post.id}>
+                      <a
+                        href={post.telegram_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-blue-600 hover:underline"
+                      >
+                        {post.title}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default HashtagGroups;


### PR DESCRIPTION
## Summary
- list posts by hashtag groups
- link hashtag page in header navigation
- register hashtag route in router

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685537a5bcc883299dfda68a786c1418