### PR TITLE
Improve Telegram history import handling

### DIFF
--- a/src/components/PostManagement.tsx
+++ b/src/components/PostManagement.tsx
@@ -63,6 +63,9 @@ export const PostManagement = () => {
 
   useEffect(() => {
     loadData();
+    const handler = () => loadData();
+    window.addEventListener('posts-imported', handler);
+    return () => window.removeEventListener('posts-imported', handler);
   }, []);
 
   const loadData = async () => {

--- a/src/components/TelegramImport.tsx
+++ b/src/components/TelegramImport.tsx
@@ -45,7 +45,8 @@ export const TelegramImport = () => {
       formData.append('file', file);
 
       const { data, error } = await supabase.functions.invoke('import-telegram-history', {
-        body: formData
+        body: formData,
+        headers: { 'Content-Type': 'multipart/form-data' }
       });
 
       if (error) {
@@ -64,12 +65,18 @@ export const TelegramImport = () => {
       const fileInput = document.getElementById('file-input') as HTMLInputElement;
       if (fileInput) fileInput.value = '';
 
-    } catch (error) {
+      // уведомляем другие компоненты об успешном импорте
+      window.dispatchEvent(new Event('posts-imported'));
+
+    } catch (error: any) {
       console.error('Import error:', error);
+      const message =
+        error?.message ??
+        (typeof error === 'string' ? error : 'Произошла ошибка при импорте данных');
       toast({
-        title: "Ошибка импорта",
-        description: error.message || "Произошла ошибка при импорте данных",
-        variant: "destructive",
+        title: 'Ошибка импорта',
+        description: message,
+        variant: 'destructive',
       });
     } finally {
       setIsLoading(false);


### PR DESCRIPTION
## Summary
- handle `import-telegram-history` errors better
- dispatch a `posts-imported` event after importing telegram history
- reload posts in `PostManagement` when history import completes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685537ae2d548329bfce58a4d0c1bb73